### PR TITLE
Add error details support

### DIFF
--- a/encoding/protobuf/header.go
+++ b/encoding/protobuf/header.go
@@ -1,0 +1,36 @@
+package protobuf
+
+import (
+	"encoding/base64"
+
+	"github.com/gogo/protobuf/proto"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/status"
+)
+
+const _grpcStatusDetailsHeaderKey = "grpc-status-details-bin"
+
+// ErrorDetailsFromHeaders pulls and decodes error details from the passed in
+// headers.
+func ErrorDetailsFromHeaders(headers map[string]string) []interface{} {
+	statusDetailsBinary := headers[_grpcStatusDetailsHeaderKey]
+
+	decodedHeader, err := decodeBinaryHeader(statusDetailsBinary)
+	if err != nil {
+		return nil
+	}
+
+	s := &spb.Status{}
+	if err := proto.Unmarshal(decodedHeader, s); err != nil {
+		return nil
+	}
+	return status.FromProto(s).Details()
+}
+
+func decodeBinaryHeader(value string) ([]byte, error) {
+	isInputPadded := len(value)%4 == 0
+	if isInputPadded {
+		return base64.StdEncoding.DecodeString(value)
+	}
+	return base64.RawStdEncoding.DecodeString(value)
+}

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -23,12 +23,13 @@ package grpc
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"io/ioutil"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
+	"github.com/gogo/protobuf/proto"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
@@ -182,7 +183,7 @@ func (o *Outbound) invoke(
 		),
 	)
 	if err != nil {
-		return invokeErrorToYARPCError(err, *responseMD)
+		return handleInvokeError(err, *responseMD)
 	}
 	// Service name match validation, return yarpcerrors.CodeInternal error if not match
 	if match, resSvcName := checkServiceMatch(request.Service, *responseMD); !match {
@@ -201,22 +202,18 @@ func metadataToIsApplicationError(responseMD metadata.MD) bool {
 	return ok && len(value) > 0 && len(value[0]) > 0
 }
 
-func invokeErrorToYARPCError(err error, responseMD metadata.MD) error {
-	if err == nil {
-		return nil
-	}
+func handleInvokeError(err error, responseMD metadata.MD) error {
 	if yarpcerrors.IsStatus(err) {
 		return err
 	}
-	status, ok := status.FromError(err)
-	// if not a yarpc error or grpc error, just return a wrapped error
+	st, ok := status.FromError(err)
+
 	if !ok {
 		return yarpcerrors.FromError(err)
 	}
-	code, ok := _grpcCodeToCode[status.Code()]
-	if !ok {
-		code = yarpcerrors.CodeUnknown
-	}
+
+	code := getCodeFromStatus(st)
+
 	var name string
 	if responseMD != nil {
 		value, ok := responseMD[ErrorNameHeader]
@@ -224,8 +221,9 @@ func invokeErrorToYARPCError(err error, responseMD metadata.MD) error {
 		if ok && len(value) == 1 {
 			name = value[0]
 		}
+		addStatusDetailsToMetadata(st, responseMD)
 	}
-	message := status.Message()
+	message := st.Message()
 	// we put the name as a prefix for grpc compatibility
 	// if there was no message, the message will be the name, so we leave it as the message
 	if name != "" && message != "" && message != name {
@@ -234,6 +232,38 @@ func invokeErrorToYARPCError(err error, responseMD metadata.MD) error {
 		message = ""
 	}
 	return intyarpcerrors.NewWithNamef(code, name, message)
+}
+
+// addStatusDetailsToMetadata adds a binary encoded marshalled proto of the
+// grpc `status.Status` object to responsseMD to later be encoded as a yarpc header.
+// This needs to be done because although grpc-go properly sends this over
+// over the wire under the header `grpc-status-details-bin`, it decodes and
+// unmarshalls it to the status.Status object and never propogates it to
+// metadata.
+func addStatusDetailsToMetadata(st *status.Status, responseMD metadata.MD) {
+	if p := st.Proto(); p != nil && len(p.Details) > 0 {
+		stBytes, err := proto.Marshal(p)
+		if err != nil {
+			// TODO: Don't panic
+			panic(err)
+		}
+		responseMD.Set(
+			_grpcStatusDetailsHeaderKey,
+			encodeBinaryHeader(stBytes),
+		)
+	}
+}
+
+func getCodeFromStatus(s *status.Status) yarpcerrors.Code {
+	code, ok := _grpcCodeToCode[s.Code()]
+	if !ok {
+		return yarpcerrors.CodeUnknown
+	}
+	return code
+}
+
+func encodeBinaryHeader(v []byte) string {
+	return base64.RawStdEncoding.EncodeToString(v)
 }
 
 // CallStream implements transport.StreamOutbound#CallStream.


### PR DESCRIPTION
Adding error details support for grpc/proto. This is pretty crummy but this is to prototype error details usage. To use:

**Server Inbound**
Return grpc status.Errors (https://godoc.org/google.golang.org/grpc/status#Error) with error details

**Client Outbound**
Retrieve the headers from the yarpc call and then pass them to `ErrorDetailsFromHeaders`

**Changes**
- Added binary encoded marshalled proto of the status.Status object to metadata under the key: `grpc-status-details-bin` on outbound. This is how it's transmitted over the wire but grpc-go filters it out since it gets decoded and unmarshalled as status.Status already. Since status is not a core concept in yarpc, we place it back in the headers for later consumption by the client.
- Added `protobuf.ErrorDetailsFromHeaders` to decode and unmarshall the error details from the headers.

**Tests**
This was tested through scripts via direct usage in the UA3 repository. If we decide to go with this solution (we probably won't), we can flesh this out. 