### PR TITLE
Add error details support

### DIFF
--- a/encoding/protobuf/header.go
+++ b/encoding/protobuf/header.go
@@ -1,0 +1,36 @@
+package protobuf
+
+import (
+	"encoding/base64"
+
+	"github.com/gogo/protobuf/proto"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/status"
+)
+
+const _grpcStatusDetailsHeaderKey = "grpc-status-details-bin"
+
+// ErrorDetailsFromHeaders pulls and decodes error details from the passed in
+// headers.
+func ErrorDetailsFromHeaders(headers map[string]string) []interface{} {
+	statusDetailsBinary := headers[_grpcStatusDetailsHeaderKey]
+
+	decodedHeader, err := decodeBinaryHeader(statusDetailsBinary)
+	if err != nil {
+		return nil
+	}
+
+	s := &spb.Status{}
+	if err := proto.Unmarshal(decodedHeader, s); err != nil {
+		return nil
+	}
+	return status.FromProto(s).Details()
+}
+
+func decodeBinaryHeader(value string) ([]byte, error) {
+	isInputPadded := len(value)%4 == 0
+	if isInputPadded {
+		return base64.StdEncoding.DecodeString(value)
+	}
+	return base64.RawStdEncoding.DecodeString(value)
+}


### PR DESCRIPTION
Adding error details support for grpc/proto. This is pretty crummy but this is to prototype error details usage. To use:

**Server Inbound**
Return grpc status.Errors (https://godoc.org/google.golang.org/grpc/status#Error) with error details

**Client Outbound**
Retrieve the headers from the yarpc call and then pass them to `ErrorDetailsFromHeaders`

**Changes**
- Added binary encoded marshalled proto of the status.Status object to metadata under the key: `grpc-status-details-bin` on outbound. This is how it's transmitted over the wire but grpc-go filters it out since it gets decoded and unmarshalled as status.Status already. Since status is not a core concept in yarpc, we place it back in the headers for later consumption by the client.
- Added `protobuf.ErrorDetailsFromHeaders` to decode and unmarshall the error details from the headers.

**Tests**
This was tested through scripts via direct usage in the UA3 repository. If we decide to go with this solution (we probably won't), we can flesh this out. 